### PR TITLE
Fix nginx listen address to localhost only

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -28,7 +28,7 @@ stream {
         }
 
         server {
-            listen        6443;
+            listen        127.0.0.1:6443;
             proxy_pass    kube_apiserver;
             proxy_timeout 10m;
             proxy_connect_timeout 1s;


### PR DESCRIPTION
There's no need for the proxy to listen to anything else than localhost.

Tested by forcing a change on local pod manifest path to hand-baked version:
```
root@pharos-worker-0:~# netstat -an | grep 6443
tcp        0      0 127.0.0.1:6443          0.0.0.0:*               LISTEN     
```